### PR TITLE
Feature/run tool checked

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.7.9.6"
+version = "0.7.9.7"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/gui/gui_main_window/gui_main_window_processing.py
+++ b/src/AV_Spex/gui/gui_main_window/gui_main_window_processing.py
@@ -51,7 +51,6 @@ class MainWindowProcessing:
         self.main_window.signals.md5_progress.connect(self.main_window.processing_window.update_detail_progress)
         self.main_window.signals.access_file_progress.connect(self.main_window.processing_window.update_detail_progress)
         self.main_window.signals.qctools_progress.connect(self.main_window.processing_window.update_detail_progress)
-        print("QCTools progress signal connected!")  # ADD THIS DEBUG LINE
             
         # Connect the step_completed signal
         self.main_window.signals.step_completed.connect(self.main_window.processing_window.mark_step_complete)
@@ -88,6 +87,8 @@ class MainWindowProcessing:
                 self.main_window.processing_window.update_status("Processing completed successfully!")
                 self.main_window.processing_window.progress_bar.setMaximum(100)
                 self.main_window.processing_window.progress_bar.setValue(100)
+                # To prevent "0%" showing when jobs are done.
+                self.main_window.processing_window.overlay_label.setText("Complete")
             
             # Change the cancel button to a close button
             self.main_window.processing_window.cancel_button.setText("Close")
@@ -257,6 +258,11 @@ class MainWindowProcessing:
             self.main_window.worker.wait()
             self.main_window.worker.deleteLater()
             self.main_window.worker = None
+
+    def on_clear_status(self):
+        """Handle status clearing"""
+        if self.main_window.processing_window:
+            self.main_window.processing_window.update_detailed_status("")
 
     def cancel_processing(self):
         """Cancel ongoing processing"""

--- a/src/AV_Spex/gui/gui_main_window/gui_main_window_signals.py
+++ b/src/AV_Spex/gui/gui_main_window/gui_main_window_signals.py
@@ -28,6 +28,8 @@ class MainWindowSignals:
         self.main_window.signals.mediaconch_progress.connect(self.main_window.processing.on_mediaconch_progress)
         self.main_window.signals.metadata_progress.connect(self.main_window.processing.on_metadata_progress)
         self.main_window.signals.output_progress.connect(self.main_window.processing.on_output_progress)
+
+        self.main_window.signals.clear_status.connect(self.main_window.processing.on_clear_status)
     
     def on_processing_window_hidden(self):
         """Handle processing window hidden event."""

--- a/src/AV_Spex/gui/gui_signals.py
+++ b/src/AV_Spex/gui/gui_signals.py
@@ -23,3 +23,5 @@ class ProcessingSignals(QObject):
     md5_progress = pyqtSignal(int)          # Signal for MD5 calculation progress percentage
     access_file_progress = pyqtSignal(int)  # Signal for access file creation progress percentage
     qctools_progress = pyqtSignal(int)       # Signal for qctools xml creation progress percentage
+
+    clear_status = pyqtSignal()  # Signal to clear status message


### PR DESCRIPTION
Handful of small gui updates and one avspex processor update. 

The processor was triggered by a conditional that was only looking for the "check_tool" option per metadata tool, it now looks for both check_tool and run_tool for both enabling metadata tools and marking the steps complete. 

Progress bar will now say "Complete" when processing is complete instead of leaving 0% visible. 

Detail status such as "Running metadata tools..." over the progress bar are now cleared after they complete.