### PR TITLE
Feature/find qct report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.7.9.7"
+version = "0.7.9.8"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/checks/qct_parse.py
+++ b/src/AV_Spex/checks/qct_parse.py
@@ -1019,7 +1019,14 @@ def run_qctparse(video_path, qctools_output_path, report_directory, check_cancel
     
     qct_parse = asdict(checks_config.tools.qct_parse)
 
-    qctools_ext = checks_config.outputs.qctools_ext
+    # Get the extension from the actual qctools file path
+    if '.qctools.mkv' in qctools_output_path:
+        qctools_ext = 'qctools.mkv'
+    elif '.qctools.xml.gz' in qctools_output_path:
+        qctools_ext = 'qctools.xml.gz'
+    else:
+        # Fallback to config if we can't determine from path
+        qctools_ext = checks_config.outputs.qctools_ext
 
     if qctools_ext.lower().endswith('mkv'):
         startObj = extract_report_mkv(startObj, qctools_output_path)


### PR DESCRIPTION
Now searches both "vrecord_metadata" and "qc_metadata" folders to find the qctools report, and uses the extension of the report itself (and not the ext in the config) to determine if the xml needs to be extracted from mkv file or not